### PR TITLE
test: agregar pruebas Jest para devolución de clientes

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "description": "backend de kajamart",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest --runInBand",
     "dev": "cross-env NODE_ENV=development nodemon src/index.js",
     "start": "node src/index.js",
     "build": "npx prisma generate",

--- a/backend/src/tests/returnClient.controller.test.js
+++ b/backend/src/tests/returnClient.controller.test.js
@@ -1,0 +1,166 @@
+jest.mock("../prisma/prismaClient", () => ({
+  devolucion_cliente: { findMany: jest.fn() },
+  ventas: { findUnique: jest.fn(), findFirst: jest.fn(), update: jest.fn() },
+  $transaction: jest.fn(),
+}));
+
+jest.mock("../controllers/returnProducts.controller", () => ({
+  getResponsable: jest.fn(),
+}));
+
+const prisma = require("../prisma/prismaClient");
+const { getResponsable } = require("../controllers/returnProducts.controller");
+const {
+  getReturnClients,
+  createReturnClients,
+  cancelReturnClient,
+} = require("../controllers/returnClient.controller");
+
+const buildRes = () => {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+describe("returnClient.controller", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("getReturnClients", () => {
+    test("debe limitar a 20 resultados máximo y devolver nextCursor", async () => {
+      const req = { query: { limit: "50" } };
+      const res = buildRes();
+
+      const rows = Array.from({ length: 21 }, (_, i) => ({
+        id_devoluciones_cliente: 100 - i,
+      }));
+      prisma.devolucion_cliente.findMany.mockResolvedValue(rows);
+
+      await getReturnClients(req, res);
+
+      expect(prisma.devolucion_cliente.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          take: 21,
+          orderBy: { id_devoluciones_cliente: "desc" },
+        }),
+      );
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        data: rows.slice(0, 20),
+        meta: { limit: 20, nextCursor: rows[19].id_devoluciones_cliente },
+      });
+    });
+  });
+
+  describe("createReturnClients", () => {
+    test("debe responder 404 cuando el responsable no existe", async () => {
+      const req = { body: { id_responsable: 999 } };
+      const res = buildRes();
+
+      getResponsable.mockResolvedValue(null);
+
+      await createReturnClients(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({ error: "Responsable no encontrado" });
+    });
+
+    test("debe responder 400 cuando hay productos fuera de la venta", async () => {
+      const req = {
+        body: {
+          id_responsable: 1,
+          id_venta: 10,
+          productosVenta: [{ id_detalle_venta: 999, cantidad: 1 }],
+          productosEntrega: [{ id_detalle_producto: 1, cantidad: 1, valor_unitario: 10 }],
+        },
+      };
+      const res = buildRes();
+
+      getResponsable.mockResolvedValue({ usuario_id: 1, nombre: "Ana", apellido: "Pérez" });
+      prisma.ventas.findUnique.mockResolvedValue({
+        id_venta: 10,
+        detalle_venta: [{ id_detalle: 100 }],
+      });
+
+      await createReturnClients(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        error: "Uno o mas productos a devolver no existen en la venta",
+      });
+    });
+  });
+
+  describe("cancelReturnClient", () => {
+    test("debe responder 400 cuando el id de devolución es inválido", async () => {
+      const req = { params: { id: "abc" }, body: { id_responsable: 1 } };
+      const res = buildRes();
+
+      await cancelReturnClient(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ error: "ID de devolucion invalido" });
+    });
+
+    test("debe responder 404 cuando la devolución a anular no existe", async () => {
+      const req = { params: { id: "22" }, body: { id_responsable: 1 } };
+      const res = buildRes();
+
+      getResponsable.mockResolvedValue({ usuario_id: 1, nombre: "Ana", apellido: "Pérez" });
+
+      prisma.$transaction.mockImplementation(async (cb) =>
+        cb({
+          devolucion_cliente: { findUnique: jest.fn().mockResolvedValue(null) },
+        }),
+      );
+
+      await cancelReturnClient(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({ error: "Devolucion al cliente no encontrada" });
+    });
+
+    test("debe anular la devolución y responder 200", async () => {
+      const req = { params: { id: "50" }, body: { id_responsable: 7 } };
+      const res = buildRes();
+
+      getResponsable.mockResolvedValue({ usuario_id: 7, nombre: "Sara", apellido: "Ruiz" });
+
+      const tx = {
+        devolucion_cliente: {
+          findUnique: jest.fn().mockResolvedValue({
+            id_devoluciones_cliente: 50,
+            id_venta: 15,
+            estado: true,
+          }),
+          update: jest.fn().mockResolvedValue({}),
+        },
+        ventas: { update: jest.fn().mockResolvedValue({}) },
+        devolucion_cliente_devuelto: {
+          findMany: jest.fn().mockResolvedValue([]),
+          updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+        },
+        devolucion_cliente_entregado: {
+          findMany: jest.fn().mockResolvedValue([]),
+          updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+        },
+        productos_baja: { findMany: jest.fn().mockResolvedValue([]), deleteMany: jest.fn() },
+        detalle_productos_baja: { deleteMany: jest.fn() },
+        detalle_productos: { update: jest.fn() },
+        productos: { update: jest.fn() },
+      };
+
+      prisma.$transaction.mockImplementation(async (cb) => cb(tx));
+
+      await cancelReturnClient(req, res);
+
+      expect(tx.devolucion_cliente.update).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id_devoluciones_cliente: 50 } }),
+      );
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ message: "Devolucion al cliente anulada con exito" });
+    });
+  });
+});


### PR DESCRIPTION
### Motivation
- Añadir pruebas automáticas para el módulo de Devolución de Clientes siguiendo la guía del taller para asegurar comportamientos críticos (paginación, creación y anulación).
- Preparar el proyecto para ejecutar Jest con un script `npm test` localmente.

### Description
- Actualiza `backend/package.json` cambiando el script `test` a `jest --runInBand` para ejecutar Jest en modo serializado.
- Añade `backend/src/tests/returnClient.controller.test.js` que contiene pruebas unitarias con Jest para el controlador de devolución de clientes, usando mocks de `../prisma/prismaClient` y de `getResponsable` (importado desde `../controllers/returnProducts.controller`).
- Los tests incluidos cubren: `getReturnClients` (límite/safeLimit y `nextCursor`), `createReturnClients` (responsable inexistente y productos fuera de la venta) y `cancelReturnClient`/`anularReturnClient` (id inválido, devolución no encontrada y flujo exitoso de anulación).

### Testing
- Intenté instalar Jest con `npm install --save-dev jest`, pero la instalación falló por restricción del registry (`403 Forbidden`) en el entorno, por lo que no se instaló ni se ejecutó la suite.
- Ejecuté `npm test` en `backend`, y falló con `sh: 1: jest: not found` porque Jest no está instalado en este entorno. (Resultado: fallo.)
- Intenté ejecutar el archivo de pruebas con `node` para validar carga, pero dio `ReferenceError: jest is not defined` dado que el runtime de Node no provee las utilidades de Jest; por tanto los tests no se pudieron ejecutar aquí.

Comandos ejecutados y resultado breve:
- `cd backend && npm install --save-dev jest` — falló (403 Forbidden del registry).
- `cd backend && npm test` — falló (`jest: not found`).
- `node -e "require('./src/tests/returnClient.controller.test.js')"` — falló (`ReferenceError: jest is not defined`).

Archivos modificados/añadidos:
- `backend/package.json` (script `test`).
- `backend/src/tests/returnClient.controller.test.js` (nuevo, tests unitarios con mocks).

Nota: por restricciones de red/entorno no se pudieron ejecutar las pruebas automatizadas aquí; el contenido del test está listo para correr en un entorno con acceso a npm (instalar `jest`) y con Node disponible.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b0db87f1f8832b8afa6bc6c969f648)