### PR TITLE
test(categories): agregar pruebas Jest para el controlador de categorías y script de test

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "description": "backend de kajamart",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest --runInBand",
     "dev": "cross-env NODE_ENV=development nodemon src/index.js",
     "start": "node src/index.js",
     "build": "npx prisma generate",
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "cross-env": "^10.1.0",
+    "jest": "^30.2.0",
     "nodemon": "^3.1.10",
     "prisma": "^6.18.0"
   }

--- a/backend/src/controllers/__tests__/categories.controller.test.js
+++ b/backend/src/controllers/__tests__/categories.controller.test.js
@@ -1,0 +1,130 @@
+const {
+  getCategories,
+  createCategory,
+  updateCategory,
+  deleteCategory,
+} = require('../categories.controller');
+
+jest.mock('../../prisma/prismaClient', () => ({
+  categorias: {
+    findMany: jest.fn(),
+    count: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    findUnique: jest.fn(),
+    delete: jest.fn(),
+  },
+}));
+
+const prisma = require('../../prisma/prismaClient');
+
+const crearRes = () => {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+describe('categories.controller', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('debe listar categorías paginadas', async () => {
+    const req = { query: { page: '2', limit: '3', search: 'hogar' } };
+    const res = crearRes();
+
+    prisma.categorias.findMany.mockResolvedValue([
+      { id_categoria: 10, nombre_categoria: 'Hogar' },
+    ]);
+    prisma.categorias.count.mockResolvedValue(7);
+
+    await getCategories(req, res);
+
+    expect(prisma.categorias.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        skip: 3,
+        take: 3,
+        orderBy: { id_categoria: 'desc' },
+      })
+    );
+    expect(prisma.categorias.count).toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith({
+      data: [{ id_categoria: 10, nombre_categoria: 'Hogar' }],
+      currentPage: 2,
+      totalPages: 3,
+      totalItems: 7,
+    });
+  });
+
+  test('debe retornar 400 si falta nombre_categoria al crear', async () => {
+    const req = { body: { descripcion_categoria: 'Sin nombre' } };
+    const res = crearRes();
+
+    await createCategory(req, res);
+
+    expect(prisma.categorias.create).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: 'El nombre de la categoría es obligatorio.',
+    });
+  });
+
+  test('debe retornar 400 si se intenta crear una categoría duplicada', async () => {
+    const req = {
+      body: {
+        nombre_categoria: 'Bebidas',
+        descripcion_categoria: 'Categoría duplicada',
+      },
+    };
+    const res = crearRes();
+
+    prisma.categorias.create.mockRejectedValue({ code: 'P2002' });
+
+    await createCategory(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: 'Ya existe una categoría con ese nombre.',
+    });
+  });
+
+  test('debe retornar 404 al actualizar una categoría inexistente', async () => {
+    const req = {
+      params: { id: '999' },
+      body: { nombre_categoria: 'Actualizada' },
+    };
+    const res = crearRes();
+
+    prisma.categorias.update.mockRejectedValue({ code: 'P2025' });
+
+    await updateCategory(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({
+      message: 'La categoría no existe o ya fue eliminada.',
+    });
+  });
+
+  test('debe retornar 400 al eliminar categoría con productos asociados', async () => {
+    const req = { params: { id: '5' } };
+    const res = crearRes();
+
+    prisma.categorias.findUnique.mockResolvedValue({
+      id_categoria: 5,
+      nombre_categoria: 'Lácteos',
+    });
+    prisma.categorias.delete.mockRejectedValue({ code: 'P2003' });
+
+    await deleteCategory(req, res);
+
+    expect(prisma.categorias.findUnique).toHaveBeenCalledWith({
+      where: { id_categoria: 5 },
+    });
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message:
+        'No se puede eliminar la categoría porque tiene productos asociados. Elimina o reasigna esos productos antes de continuar.',
+    });
+  });
+});


### PR DESCRIPTION
### Motivation
- Añadir pruebas unitarias para garantizar el comportamiento del controlador de categorías y facilitar la detección de regresiones en las operaciones CRUD.

### Description
- Actualicé `backend/package.json` para ejecutar tests con `jest --runInBand` y añadí `jest` en `devDependencies`.
- Añadí el archivo de pruebas `backend/src/controllers/__tests__/categories.controller.test.js` que mockea `prisma` y contiene tests unitarios para el controlador de categorías.
- Los tests cubren: listado paginado, validación de `nombre_categoria` obligatorio al crear, manejo de error por nombre duplicado (`P2002`), actualización de categoría inexistente (`P2025`) y eliminación bloqueada por FK (`P2003`).

### Testing
- Intenté instalar dependencias con `npm install` en `/workspace/kajamar_backend/backend`, pero la instalación falló por un `403 Forbidden` al descargar `jest` desde el registry; por tanto no se pudieron ejecutar los tests automatizados.
- Ejecuté `npm test` y falló con `jest: not found` porque `jest` no se instaló en este entorno; los archivos de test y el script fueron creados correctamente y están listos para ejecutarse una vez se instalen las dependencias.
- Los tests añadidos son unitarios con mocks de Prisma y están diseñados para correr con `jest` (por ejemplo con `npx jest src/controllers/__tests__/categories.controller.test.js --runInBand`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b191a2c3bc832ba620e427d8a327cf)