### PR TITLE
fix: mitigate prisma dependency audit by overriding effect

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -25,9 +25,14 @@
         "cross-env": "^10.1.0",
         "jest": "^30.3.0",
         "nodemon": "^3.1.10",
-        "prisma": "^6.18.0",
+        "prisma": "^6.19.2",
         "prisma-erd-generator": "^2.4.2",
         "supertest": "^7.2.2"
+      },
+      "overrides": {
+        "@prisma/config": {
+          "effect": "3.20.0"
+        }
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -38,8 +38,13 @@
     "cross-env": "^10.1.0",
     "jest": "^30.3.0",
     "nodemon": "^3.1.10",
-    "prisma": "^6.18.0",
+    "prisma": "^6.19.2",
     "prisma-erd-generator": "^2.4.2",
     "supertest": "^7.2.2"
+  },
+  "overrides": {
+    "@prisma/config": {
+      "effect": "3.20.0"
+    }
   }
 }


### PR DESCRIPTION
### Motivation
- The audit reported a high-severity issue coming from `effect` (v3.18.4) brought in via `prisma -> @prisma/config -> effect`, so a minimal mitigation was required to avoid forcing a Prisma major upgrade.
- The goal is to remove the vulnerable `effect` version from the resolved tree while keeping runtime behavior unchanged and avoiding breaking changes.

### Description
- Updated the backend `devDependencies.prisma` range from `^6.18.0` to `^6.19.2` to align with the version already resolved in the lockfile and avoid mixed ranges in the tree.
- Added an `overrides` entry in `backend/package.json` to force `@prisma/config` to resolve `effect` to `3.20.0` (safe line) instead of the vulnerable `3.18.4`.
- Mirrored the `overrides` and the `prisma` devDependency bump in `backend/package-lock.json` so the package metadata is consistent with the `package.json` change.

### Testing
- Ran `npm test -- --runInBand`, which executed the test suite but failed due to a pre-existing `categories.controller` test expectation mismatch that is unrelated to the dependency changes.
- Verified the package changes with `node -e "const pkg=require('./backend/package.json'); console.log(pkg.devDependencies.prisma); console.log(JSON.stringify(pkg.overrides,null,2));"`, which returned the updated `prisma` range and the `overrides` entry.
- Attempted `npm audit --json` but the environment returned `403 Forbidden` for the registry audit endpoint, so the advisory re-query could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c1c8fd1ef4832b9ec7d28fc45ef476)