### PR TITLE
seguridad: remediar dependencias vulnerables y endurecer manejo de uploads

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,17 +1,17 @@
 # -------- deps --------
-FROM node:20-alpine AS deps
+FROM node:22-alpine3.22 AS deps
 WORKDIR /app
 
 # Prisma en Alpine suele necesitar openssl
-RUN apk add --no-cache openssl
+RUN apk update && apk upgrade --no-cache && apk add --no-cache openssl
 
 COPY package*.json ./
 RUN npm ci
 
 # -------- build --------
-FROM node:20-alpine AS build
+FROM node:22-alpine3.22 AS build
 WORKDIR /app
-RUN apk add --no-cache openssl
+RUN apk update && apk upgrade --no-cache && apk add --no-cache openssl
 
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
@@ -23,10 +23,10 @@ RUN npx prisma generate
 # RUN npm run build
 
 # -------- runtime --------
-FROM node:20-alpine AS runtime
+FROM node:22-alpine3.22 AS runtime
 WORKDIR /app
 ENV NODE_ENV=production
-RUN apk add --no-cache openssl
+RUN apk update && apk upgrade --no-cache && apk add --no-cache openssl
 
 # Copiamos app
 COPY --from=build /app ./

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -1,15 +1,15 @@
 # -------- deps --------
-FROM node:20-alpine AS deps
+FROM node:22-alpine3.22 AS deps
 WORKDIR /app
-RUN apk add --no-cache openssl
+RUN apk update && apk upgrade --no-cache && apk add --no-cache openssl
 
 COPY package*.json ./
 RUN npm ci
 
 # -------- build --------
-FROM node:20-alpine AS build
+FROM node:22-alpine3.22 AS build
 WORKDIR /app
-RUN apk add --no-cache openssl
+RUN apk update && apk upgrade --no-cache && apk add --no-cache openssl
 
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
@@ -18,10 +18,10 @@ COPY . .
 RUN npx prisma generate
 
 # -------- runtime --------
-FROM node:20-alpine AS runtime
+FROM node:22-alpine3.22 AS runtime
 WORKDIR /app
 ENV NODE_ENV=production
-RUN apk add --no-cache openssl
+RUN apk update && apk upgrade --no-cache && apk add --no-cache openssl
 
 COPY --from=build /app ./
 

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   api:
-    image: node:20-alpine
+    image: node:22-alpine3.22
     working_dir: /app
     ports:
       - "3000:3000"

--- a/backend/package.json
+++ b/backend/package.json
@@ -39,13 +39,17 @@
     "jest": "^30.3.0",
     "nodemon": "^3.1.10",
     "prisma": "^6.19.2",
-    "prisma-erd-generator": "^2.4.2",
     "supertest": "^7.2.2"
   },
   "overrides": {
     "@prisma/config": {
       "effect": "3.20.0"
     },
-    "lodash-es": "4.18.1"
+    "lodash-es": "4.18.1",
+    "basic-ftp": "^5.2.1",
+    "cross-spawn": "^7.0.7",
+    "glob": "^11.0.1",
+    "minimatch": "^10.0.3",
+    "tar": "^7.4.3"
   }
 }

--- a/backend/src/routes/products.routes.js
+++ b/backend/src/routes/products.routes.js
@@ -1,6 +1,7 @@
 // backend/src/routes/products.routes.js
 const express = require("express");
 const router = express.Router();
+const fs = require("fs");
 const multer = require("multer");
 const path = require("path");
 
@@ -17,17 +18,50 @@ const {
   searchProducts,
 } = require("../controllers/products.controller");
 
+const allowedImageMimeTypes = new Map([
+  ["image/jpeg", ".jpg"],
+  ["image/jpg", ".jpg"],
+  ["image/png", ".png"],
+  ["image/webp", ".webp"],
+]);
+
+const uploadsDir = path.join(__dirname, "..", "uploads");
+if (!fs.existsSync(uploadsDir)) {
+  fs.mkdirSync(uploadsDir, { recursive: true });
+}
+
 // Config multer (carpeta uploads/)
 const storage = multer.diskStorage({
-  destination: path.join(__dirname, "..", "uploads"),
+  destination: uploadsDir,
   filename: (_req, file, cb) => {
     const unique = Date.now() + "-" + Math.round(Math.random() * 1e9);
-    const ext = path.extname(file.originalname);
-    cb(null, `${unique}${ext}`);
+    const ext = allowedImageMimeTypes.get(file.mimetype);
+    cb(null, `${unique}${ext || ".bin"}`);
   },
 });
 
-const upload = multer({ storage });
+const upload = multer({
+  storage,
+  limits: { fileSize: 5 * 1024 * 1024 },
+  fileFilter: (_req, file, cb) => {
+    if (!allowedImageMimeTypes.has(file.mimetype)) {
+      cb(new Error("Archivo inválido. Solo se permiten imágenes JPG, PNG o WebP."));
+      return;
+    }
+
+    cb(null, true);
+  },
+});
+
+const handleUploadImage = (req, res, next) => {
+  upload.single("imagen")(req, res, (err) => {
+    if (err) {
+      return res.status(400).json({ message: err.message });
+    }
+
+    next();
+  });
+};
 
 // Rutas
 router.get("/", getAllProducts);
@@ -35,14 +69,11 @@ router.get("/all", getProducts);
 router.get("/search", searchProducts);
 router.get("/supplier/:id", getProductsBySupplier);
 router.get("/random", getRandomProduct);
-router.get("/category", getProductsByCategory),
+router.get("/category", getProductsByCategory);
 router.get("/:id", getProductById);
 
-
-// 👇 aquí usamos upload.single("imagen")
-router.post("/", upload.single("imagen"), createProduct);
-router.put("/:id", upload.single("imagen"), updateProduct);
-
+router.post("/", handleUploadImage, createProduct);
+router.put("/:id", handleUploadImage, updateProduct);
 
 router.delete("/:id", deleteProduct);
 

--- a/backend/src/routes/purchase.routes.js
+++ b/backend/src/routes/purchase.routes.js
@@ -6,16 +6,17 @@ const purchaseController = require("../controllers/purchase.controller");
 const fs = require("fs");
 const multer = require("multer");
 const path = require("path");
-const allowedImageMimeTypes = new Set([
-  "image/jpeg",
-  "image/png",
-  "image/jpg",
-  "image/webp",
+
+const allowedImageExtensions = new Map([
+  ["image/jpeg", ".jpg"],
+  ["image/jpg", ".jpg"],
+  ["image/png", ".png"],
+  ["image/webp", ".webp"],
 ]);
 
 // ✅ Guarda archivo físico en: backend/src/uploads
 const storage = multer.diskStorage({
-  destination: (req, file, cb) => {
+  destination: (_req, _file, cb) => {
     const uploadsDir = path.join(__dirname, "../uploads");
 
     try {
@@ -25,21 +26,28 @@ const storage = multer.diskStorage({
       cb(error);
     }
   },
-  filename: (req, file, cb) => {
-    const ext = path.extname(file.originalname || "");
-    const base = path
-      .basename(file.originalname || "comprobante", ext)
-      .replace(/\s+/g, "_")
-      .replace(/[^\w\-]/g, "");
+  filename: (_req, file, cb) => {
+    const ext = allowedImageExtensions.get(file.mimetype);
+    if (!ext) {
+      cb(new Error("Tipo de archivo no permitido"));
+      return;
+    }
 
-    cb(null, `${Date.now()}-${base}${ext}`);
+    const base = path
+      .basename(file.originalname || "comprobante", path.extname(file.originalname || ""))
+      .replace(/\s+/g, "_")
+      .replace(/[^\w\-]/g, "")
+      .slice(0, 80);
+
+    cb(null, `${Date.now()}-${base || "comprobante"}${ext}`);
   },
 });
 
 const upload = multer({
   storage,
+  limits: { fileSize: 5 * 1024 * 1024 },
   fileFilter: (_req, file, cb) => {
-    if (allowedImageMimeTypes.has(file.mimetype)) {
+    if (allowedImageExtensions.has(file.mimetype)) {
       cb(null, true);
       return;
     }

--- a/backend/src/routes/returnProducts.routes.js
+++ b/backend/src/routes/returnProducts.routes.js
@@ -5,11 +5,11 @@ const fs = require("fs");
 const path = require("path");
 const returnProductsController = require("../controllers/returnProducts.controller");
 
-const allowedImageMimeTypes = new Set([
-  "image/jpeg",
-  "image/png",
-  "image/jpg",
-  "image/webp",
+const allowedImageExtensions = new Map([
+  ["image/jpeg", ".jpg"],
+  ["image/jpg", ".jpg"],
+  ["image/png", ".png"],
+  ["image/webp", ".webp"],
 ]);
 
 const storage = multer.diskStorage({
@@ -24,20 +24,27 @@ const storage = multer.diskStorage({
     }
   },
   filename: (_req, file, cb) => {
-    const ext = path.extname(file.originalname || "");
-    const base = path
-      .basename(file.originalname || "comprobante", ext)
-      .replace(/\s+/g, "_")
-      .replace(/[^\w\-]/g, "");
+    const ext = allowedImageExtensions.get(file.mimetype);
+    if (!ext) {
+      cb(new Error("Tipo de archivo no permitido"));
+      return;
+    }
 
-    cb(null, `${Date.now()}-${base}${ext}`);
+    const base = path
+      .basename(file.originalname || "comprobante", path.extname(file.originalname || ""))
+      .replace(/\s+/g, "_")
+      .replace(/[^\w\-]/g, "")
+      .slice(0, 80);
+
+    cb(null, `${Date.now()}-${base || "comprobante"}${ext}`);
   },
 });
 
 const upload = multer({
   storage,
+  limits: { fileSize: 5 * 1024 * 1024 },
   fileFilter: (_req, file, cb) => {
-    if (allowedImageMimeTypes.has(file.mimetype)) {
+    if (allowedImageExtensions.has(file.mimetype)) {
       cb(null, true);
       return;
     }


### PR DESCRIPTION
### Motivation
- Remediar múltiples vulnerabilidades en el stack (zlib en Alpine y varias dependencias npm transitivas como basic-ftp, cross-spawn, glob, minimatch, tar) para dejar el backend listo para producción.
- Minimizar cambios de funcionalidad mientras se corrigen vectores de ataque del sistema operativo, dependencias y manejo de archivos subidos.

### Description
- Se actualizó la base de las imágenes de contenedor de `node:20-alpine` a `node:22-alpine3.22` y se añadió `apk update && apk upgrade --no-cache` en todos los stages para aplicar parches de sistema (incluido zlib); archivos modificados: `backend/Dockerfile`, `backend/Dockerfile.prod` y `backend/docker-compose.yml`.
- Se endureció la política de dependencias en `backend/package.json` removiendo `prisma-erd-generator` (vector transitivo) y añadiendo `overrides` para forzar versiones seguras de `basic-ftp`, `cross-spawn`, `glob`, `minimatch` y `tar`.
- Se reforzó el manejo de uploads en las rutas críticas para evitar path traversal y uploads peligrosos mediante allowlist por MIME con extensión derivada del MIME (no del nombre cliente), sanitización de basename limitada a 80 caracteres, límite de tamaño (`5MB`) y respuestas 400 coherentes; archivos modificados: `backend/src/routes/products.routes.js`, `backend/src/routes/purchase.routes.js`, `backend/src/routes/returnProducts.routes.js`.
- No se introdujeron cambios en la lógica de negocio fuera de la validación y seguridad de entrada, y las modificaciones mantienen compatibilidad esperada salvo que clientes que suban archivos no válidos los verán rechazados.

### Testing
- Ejecuté `npm run build` y la generación de Prisma Client fue exitosa (`npx prisma generate`) y terminó sin errores.
- Ejecuté la suite de tests con `npm test` donde la ejecución falló con 1 test fallido en `categories.controller.test.js` por una expectativa preexistente que no fue causada por estos cambios (40 tests pasaron, 1 falló).
- Intentos de regenerar el lockfile con `npm install --package-lock-only` y de comprobar vulnerabilidades con `npm audit` quedaron bloqueados por la política del registro en este entorno (`403 Forbidden`), por lo que el lockfile no pudo actualizarse aquí y la materialización final de `overrides` debe validarse en CI con acceso al registry.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d7caa33e688327bb486bd6fe06d31f)